### PR TITLE
New generic TimeLock contract

### DIFF
--- a/governance/contracts/lock/TimeLock.sol
+++ b/governance/contracts/lock/TimeLock.sol
@@ -1,0 +1,58 @@
+pragma solidity ^0.6.0;
+import "@c-layer/common/contracts/operable/Ownable.sol";
+
+
+/**
+ * @title TimeLock
+ * @dev Time locked contract
+ * @author Cyril Lapinte - <cyril@openfiz.com>
+ * SPDX-License-Identifier: MIT
+ *
+ * Error messages
+ *   TL01: Contract is locked
+ *   TL02: Target must be defined
+ *   TL03: Cannot be locked in the past
+ *   TL04: Execution must be successfull
+ */
+contract TimeLock is Ownable {
+
+  address payable public target;
+  uint64 public lockedUntil;
+
+  modifier whenUnlocked() {
+    require(lockedUntil < currentTime(), "TL01");
+    _;
+  }
+
+  constructor(address payable _target, uint64 _lockedUntil) public {
+    require(_target != address(0), "TL02");
+    require(_lockedUntil > currentTime(), "TL03");
+    lockedUntil = _lockedUntil;
+    target = _target;
+  }
+
+  receive() external payable {
+    require(callInternal(), "TL04");
+  }
+
+  fallback() external payable {
+    require(callInternal(), "TL04");
+  }
+
+  function callInternal() internal onlyOwner whenUnlocked returns (bool) {
+    (bool success, ) =
+    // solhint-disable-next-line avoid-call-value, avoid-low-level-calls
+    target.call{value: msg.value}(msg.data);
+    return success;
+  }
+
+  /**
+   * @dev current time
+   */
+  function currentTime() internal view returns (uint256) {
+    // solhint-disable-next-line not-rely-on-time
+    return now;
+  }
+}
+
+

--- a/governance/contracts/mock/TimeLockMock.sol
+++ b/governance/contracts/mock/TimeLockMock.sol
@@ -1,0 +1,25 @@
+pragma solidity ^0.6.0;
+  
+import "../lock/TimeLock.sol";
+
+
+/**
+ * @title TimeLockMock
+ * @dev Generic TimeLock
+ * @author Cyril Lapinte - <cyril@openfiz.com>
+ * @author Guillaume Goutaudier - <ggoutaudier@swissledger.io>
+ * SPDX-License-Identifier: MIT
+ *
+ * Error messages
+ */
+contract TimeLockMock is TimeLock {
+
+  constructor(address payable _target, uint64 _lockedUntil)
+    public TimeLock(_target, _lockedUntil) {}
+
+  function setLockedUntilTest(uint64 _lockedUntil) public returns (bool) {
+    lockedUntil = _lockedUntil;
+    return true;
+  }
+}
+

--- a/governance/test/lock/TimeLock.js
+++ b/governance/test/lock/TimeLock.js
@@ -1,0 +1,63 @@
+'user strict';
+
+/**
+ * @author Cyril Lapinte - <cyril@openfiz.com>
+ * @author Guillaume Goutaudier - <ggoutaudier@swissledger.io>
+ */
+
+const assertRevert = require('../helpers/assertRevert');
+const TimeLockMock = artifacts.require('mock/TimeLockMock.sol');
+const TimeLock = artifacts.require('lock/TimeLock.sol');
+const Token = artifacts.require('mock/TokenERC20Mock.sol');
+const unlock_time_in_future = Math.floor(new Date().getTime()/1000) + 3600;
+const unlock_time_in_past = Math.floor(new Date().getTime()/1000) - 3600;
+const NULL_ADDRESS = '0x'.padEnd(42, '0');
+
+
+contract('TimeLock', function (accounts) {
+  let target, token;
+
+  beforeEach(async function () {
+    // We will use a Token as target of the TimeLock
+    token = await Token.new('Name', 'Symbol', 0, accounts[0], 100);
+  });
+
+  it('should not allow creation of TimeLock without a target', async function () {
+    await assertRevert(TimeLock.new(NULL_ADDRESS, unlock_time_in_future), 'TL02');
+  });
+
+  it('should not allow creation of TimeLock in the past', async function () {
+    await assertRevert(TimeLock.new(token.address, unlock_time_in_past), 'TL03');
+  });
+
+  describe('after successful TimeLock contract creation', function () {
+    beforeEach(async function () {
+      timelock = await TimeLockMock.new(token.address, unlock_time_in_future);
+      timelock_target = await Token.at(timelock.address);
+      await token.transfer(timelock.address, 100);
+    });
+
+    it('should not allow any fallback() to the target before timelock expiration', async function () {
+      await assertRevert(timelock_target.transfer(accounts[1], 10), 'TL01');
+    });
+
+    describe('after timelock expiration', function() {
+      beforeEach(async function () {
+        await timelock.setLockedUntilTest(unlock_time_in_past);
+      });
+
+      it('should fail if target call is not successful', async function () {
+        await assertRevert(timelock_target.transfer(accounts[1], 1000), 'TL04');
+      });
+
+      it('should fail if target call is not successful (with ETH being received)', async function () {
+        await assertRevert(web3.eth.sendTransaction({from:accounts[0], to:timelock.address, value:1}), 'TL04');
+      });
+
+      it('should execute correctly if target call is successful', async function () {
+	await timelock_target.transfer(accounts[1], 10);
+      });
+    });
+  });
+});
+


### PR DESCRIPTION
This is a proposal to add a generic TimeLock contract to the governance smart contracts.
Such a contract can be very useful to create/extend token vaults, but can also be used in a more generic manner to create locks on any contract.
This request includes some test cases with 100% code coverage.
